### PR TITLE
Add WMT evaluation script

### DIFF
--- a/evaluation/datasets/wmt.py
+++ b/evaluation/datasets/wmt.py
@@ -1,2 +1,21 @@
-# Module for any additional processing required for the WMT dataset
-# HuggingFace dataset link: https://huggingface.co/datasets/wmt19
+from datasets import load_dataset
+from torch.utils.data import Dataset
+
+
+class WMTEnglishDataset(Dataset):
+    def __init__(self, tokenizer, stride=512, max_len=1024, pair="kk-en"):
+        super().__init__()
+        assert (
+            "en" in pair
+        ), f"Expected `pair` to contain English, but got {pair} instead"
+        wmt = load_dataset("wmt19", pair, split="validation")["translation"]
+        text_list = [item["en"] for item in wmt]
+        text = " ".join(text_list)
+        input_ids = tokenizer(text, return_tensors="pt").input_ids.squeeze()
+        self.input_ids = input_ids.unfold(size=max_len, step=stride, dimension=-1)
+
+    def __len__(self):
+        return len(self.input_ids)
+
+    def __getitem__(self, index):
+        return self.input_ids[index]

--- a/evaluation/datasets/wmt.py
+++ b/evaluation/datasets/wmt.py
@@ -11,7 +11,7 @@ class WMTEnglishDataset(Dataset):
         wmt = load_dataset("wmt19", pair, split="validation")["translation"]
         text_list = [item["en"] for item in wmt]
         text = " ".join(text_list)
-        input_ids = tokenizer(text, return_tensors="pt").input_ids.squeeze()
+        input_ids = tokenizer(text, return_tensors="pt", verbose=False).input_ids.squeeze()
         self.input_ids = input_ids.unfold(size=max_len, step=stride, dimension=-1)
 
     def __len__(self):

--- a/evaluation/scripts/wmt.py
+++ b/evaluation/scripts/wmt.py
@@ -6,12 +6,12 @@ from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
-def load_wmt(tokenizer):
+def load_wmt():
     wmt19 = load_dataset("wmt19", "kk-en")
     validation_set = wmt19["validation"]["translation"]
     text_list = [item["en"] for item in validation_set]
     text = " ".join(text_list)
-    return tokenizer(text, return_tensors="pt")
+    return text
 
 
 def main(args):
@@ -20,10 +20,11 @@ def main(args):
     device = torch.device("cuda")
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model).to(device)
-    tokens = load_wmt(tokenizer)
     max_length = model.config.n_positions
-    log_likelihoods = []
+    text = load_wmt()
+    tokens = tokenizer(text, return_tensors="pt")
     total_length = tokens.input_ids.size(1)
+    log_likelihoods = []
     for i in tqdm(range(0, total_length, stride)):
         begin_loc = max(i + stride - max_length, 0)
         end_loc = min(i + stride, total_length)
@@ -43,5 +44,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, default="gpt2")
     parser.add_argument("--stride", type=int, default=512)
+    parser.add_argument("--batch", type=int, default=-1)
     args = parser.parse_args()
     main(args)

--- a/evaluation/scripts/wmt.py
+++ b/evaluation/scripts/wmt.py
@@ -1,49 +1,49 @@
 import argparse
 
 import torch
-from datasets import load_dataset
+from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-
-def load_wmt():
-    wmt19 = load_dataset("wmt19", "kk-en")
-    validation_set = wmt19["validation"]["translation"]
-    text_list = [item["en"] for item in validation_set]
-    text = " ".join(text_list)
-    return text
+from ..datasets.wmt import WMTEnglishDataset
 
 
 def main(args):
     """adapted from https://huggingface.co/transformers/perplexity.html"""
     stride = args.stride
-    device = torch.device("cuda")
+    device = torch.device(args.device)
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model).to(device)
-    max_length = model.config.n_positions
-    text = load_wmt()
-    tokens = tokenizer(text, return_tensors="pt")
-    total_length = tokens.input_ids.size(1)
+    dataset = WMTEnglishDataset(
+        tokenizer, stride=stride, max_len=model.config.n_positions, pair=args.pair,
+    )
+    loader = DataLoader(
+        dataset, 
+        batch_size=args.batch_size, 
+        shuffle=False, 
+        num_workers=args.num_workers,
+        drop_last=True,
+    )
     log_likelihoods = []
-    for i in tqdm(range(0, total_length, stride)):
-        begin_loc = max(i + stride - max_length, 0)
-        end_loc = min(i + stride, total_length)
-        trg_len = end_loc - i
-        input_ids = tokens.input_ids[:, begin_loc:end_loc].to(device)
+    for input_ids in tqdm(loader):
+        input_ids = input_ids.to(device)
         target_ids = input_ids.clone()
-        target_ids[:, :-trg_len] = -100
+        target_ids[:, :-stride] = -100
         with torch.no_grad():
             outputs = model(input_ids, labels=target_ids)
-            log_likelihood = outputs[0] * trg_len
+            log_likelihood = outputs[0]
         log_likelihoods.append(log_likelihood)
-    perplexity = torch.exp(torch.stack(log_likelihoods).sum() / end_loc)
+    perplexity = torch.exp(torch.stack(log_likelihoods).sum() / len(loader))
     print(f"perplexity: {perplexity.item():.3f}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=str, default="cuda")
     parser.add_argument("--model", type=str, default="gpt2")
     parser.add_argument("--stride", type=int, default=512)
-    parser.add_argument("--batch", type=int, default=-1)
+    parser.add_argument("--pair", type=str, default="kk-en")
+    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--num_workers", type=int, default=4)
     args = parser.parse_args()
     main(args)

--- a/evaluation/scripts/wmt.py
+++ b/evaluation/scripts/wmt.py
@@ -1,0 +1,46 @@
+import argparse
+
+import torch
+from datasets import load_dataset
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def load_wmt(tokenizer):
+    wmt19 = load_dataset("wmt19", "kk-en")
+    validation_set = wmt19["validation"]["translation"]
+    text_list = [item["en"] for item in validation_set]
+    text = " ".join(text_list)
+    return tokenizer(text, return_tensors="pt")
+
+
+def main(args):
+    stride = args.stride
+    device = torch.device("cuda")
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForCausalLM.from_pretrained(args.model).to(device)
+    input_ids = load_wmt(tokenizer).input_ids.to(device)
+    max_length = model.config.n_positions
+    log_likelihoods = []
+    total_length = input_ids.size(1)
+    for i in tqdm(range(0, total_length, stride)):
+        begin_loc = max(i + stride - max_length, 0)
+        end_loc = min(i + stride, total_length)
+        trg_len = end_loc - i
+        input_ids = input_ids[:, begin_loc:end_loc].to(device)
+        target_ids = input_ids.clone()
+        target_ids[:, :-trg_len] = -100
+        with torch.no_grad():
+            outputs = model(input_ids, labels=target_ids)
+            log_likelihood = outputs[0] * trg_len
+        log_likelihoods.append(log_likelihood)
+    perplexity = torch.exp(torch.stack(lls).sum() / end_loc)
+    print(perplexity)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, default="gpt2")
+    parser.add_argument("--stride", type=int, default=512)
+    args = parser.parse_args()
+    main(args)

--- a/evaluation/scripts/wmt.py
+++ b/evaluation/scripts/wmt.py
@@ -15,13 +15,16 @@ def main(args):
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model).to(device)
     dataset = WMTEnglishDataset(
-        tokenizer, stride=stride, max_len=model.config.n_positions, pair=args.pair,
+        tokenizer,
+        stride=stride,
+        max_len=model.config.n_positions,
+        pair=args.pair,
     )
     loader = DataLoader(
-        dataset, 
-        batch_size=args.batch_size, 
-        shuffle=False, 
+        dataset,
+        batch_size=args.batch_size,
         num_workers=args.num_workers,
+        shuffle=False,
         drop_last=True,
     )
     log_likelihoods = []

--- a/evaluation/scripts/wmt.py
+++ b/evaluation/scripts/wmt.py
@@ -15,27 +15,28 @@ def load_wmt(tokenizer):
 
 
 def main(args):
+    """adapted from https://huggingface.co/transformers/perplexity.html"""
     stride = args.stride
     device = torch.device("cuda")
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model).to(device)
-    input_ids = load_wmt(tokenizer).input_ids.to(device)
+    tokens = load_wmt(tokenizer)
     max_length = model.config.n_positions
     log_likelihoods = []
-    total_length = input_ids.size(1)
+    total_length = tokens.input_ids.size(1)
     for i in tqdm(range(0, total_length, stride)):
         begin_loc = max(i + stride - max_length, 0)
         end_loc = min(i + stride, total_length)
         trg_len = end_loc - i
-        input_ids = input_ids[:, begin_loc:end_loc].to(device)
+        input_ids = tokens.input_ids[:, begin_loc:end_loc].to(device)
         target_ids = input_ids.clone()
         target_ids[:, :-trg_len] = -100
         with torch.no_grad():
             outputs = model(input_ids, labels=target_ids)
             log_likelihood = outputs[0] * trg_len
         log_likelihoods.append(log_likelihood)
-    perplexity = torch.exp(torch.stack(lls).sum() / end_loc)
-    print(perplexity)
+    perplexity = torch.exp(torch.stack(log_likelihoods).sum() / end_loc)
+    print(f"perplexity: {perplexity.item():.3f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Note**: This is work in progress.

This PR implements the following:
* Load the English validation portion of WMT 19
* Load an AR model to run CLM, with `stride` tokens given as context
* Report perplexity, normalized by the number of tokens

Estimated runtime on GPU is ~1 minute; CPU, ~10 minutes.

This PR should be merged after TyDiQA is integrated to `main` to reduce conflicts in `simple_benchmark.py`, which should eventually support all three simple evaluation datasets (TyDiQA, WMT, LAMBADA).