### PR TITLE
Add TyDi QA to Simple Benchmark 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # Jetbrain files
 .idea/
+
+# Outoupt files
+outputs/*

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ A [simple benchmark](https://github.com/bigscience-workshop/Megatron-DeepSpeed/i
 [WMT](https://huggingface.co/datasets/wmt19) and [TyDi QA](https://huggingface.co/datasets/tydiqa)
 E.g.
 ```shell
-python3 -m evaluation.scripts.simple_benchmark  --model_name_or_path=gpt-2
+python3 -m evaluation.scripts.simple_benchmark  --model_name_or_path=gpt2
 ```

--- a/evaluation/datasets/tydiqa.py
+++ b/evaluation/datasets/tydiqa.py
@@ -48,7 +48,7 @@ class TyDiQADataset(Dataset):
                         "input_ids": inputs["input_ids"],
                         "attention_mask": inputs["attention_mask"],
                         "input_len": inputs["attention_mask"].shape[1],
-                        "target_answer": sample["answers"]['text'][0].lower(),
+                        "target_answer": [ans.lower() for ans in sample["answers"]['text']],
                     }
                 )
     

--- a/evaluation/datasets/tydiqa.py
+++ b/evaluation/datasets/tydiqa.py
@@ -39,8 +39,7 @@ class TyDiQADataset(Dataset):
                 # Tokenize and construct this sample
                 inputs = tokenizer(
                     prompt,
-                    max_length=tokenizer.model_max_length,
-                    padding="max_length",
+                    padding=True,
                     return_tensors='pt',
                 )
                 label_ids = [tokenizer(answer)["input_ids"] for answer in sample["answers"]["text"]]
@@ -51,7 +50,7 @@ class TyDiQADataset(Dataset):
                         "input_ids": inputs["input_ids"],
                         "attention_mask": inputs["attention_mask"],
                         "label_ids": label_ids,
-                        "input_len": sum(inputs["attention_mask"]),
+                        "input_len": inputs["attention_mask"].shape[1],
                         "answers": sample["answers"],
                     }
                 )
@@ -60,12 +59,4 @@ class TyDiQADataset(Dataset):
         return len(self.items)
     
     def __getitem__(self, index):
-        item = self.items[index]
-        return {
-            "prompt": item["prompt"],
-            "lang": item["lang"],
-            "input_ids": torch.tensor(item["input_ids"]),
-            "attention_mask": torch.tensor(item["attention_mask"]),
-            "label_ids": item["label_ids"],
-        }
-
+        return self.items[index]

--- a/evaluation/datasets/tydiqa.py
+++ b/evaluation/datasets/tydiqa.py
@@ -1,2 +1,66 @@
 # Module for any additional processing required for the TyDi QA dataset
 # HuggingFace dataset link: https://huggingface.co/datasets/tydiqa
+
+import torch
+from torch.utils.data import Dataset
+from jinja2 import Template
+
+TEMPLATE = Template(
+    """
+    {%- set _blank=["passage", "text", "text snippet", "context"]|random -%}
+    {%- set _position = ["above", "following"] |random -%}
+    {%- if  _position == "above" -%}
+    {{context}}{{"\n"}}
+    {%- endif -%}
+    Given the {{_position}} {{_blank}}, answer the question: {{question}}
+    {%- if  _position == "following" -%}
+    {{"\n"}}{{context}}
+    {%- endif -%}
+    {{"\n"}}Answer: 
+    """
+)
+
+class TyDiQADataset(Dataset):
+    def __init__(self, data, tokenizer, target_langs):
+        super(TyDiQADataset, self).__init__()
+        self.items = []
+        
+        for sample_id, sample in enumerate(data):
+            lang = sample["id"].split("-")[0]
+            if lang in target_langs:
+                # Filter out samples in languages that are not used during training
+                prompt = TEMPLATE.render(
+                    id       = sample["id"],
+                    context  = sample["context"],
+                    question = sample["question"],
+                )
+                prompt = tokenizer.bos_token + " " + prompt.strip()  # Remove trailing white space and newline
+
+                # Tokenize and construct this sample
+                inputs = tokenizer(prompt, max_length=tokenizer.model_max_length,  padding="max_length") 
+                label_ids = [tokenizer(answer)["input_ids"] for answer in sample["answers"]["text"]]
+                self.items.append(
+                    {
+                        "prompt": prompt,
+                        "lang": lang,
+                        "input_ids": inputs["input_ids"],
+                        "attention_mask": inputs["attention_mask"],
+                        "label_ids": label_ids,
+                        "input_len": sum(inputs["attention_mask"]),
+                        "answers": sample["answers"],
+                    }
+                )
+    
+    def __len__(self):
+        return len(self.items)
+    
+    def __getitem__(self, index):
+        item = self.items[index]
+        return {
+            "prompt": item["prompt"],
+            "lang": item["lang"],
+            "input_ids": torch.tensor(item["input_ids"]),
+            "attention_mask": torch.tensor(item["attention_mask"]),
+            "label_ids": item["label_ids"],
+        }
+

--- a/evaluation/datasets/tydiqa.py
+++ b/evaluation/datasets/tydiqa.py
@@ -34,10 +34,15 @@ class TyDiQADataset(Dataset):
                     context  = sample["context"],
                     question = sample["question"],
                 )
-                prompt = tokenizer.bos_token + " " + prompt.strip()  # Remove trailing white space and newline
+                prompt = prompt.strip()  # Remove trailing white space and newline
 
                 # Tokenize and construct this sample
-                inputs = tokenizer(prompt, max_length=tokenizer.model_max_length,  padding="max_length") 
+                inputs = tokenizer(
+                    prompt,
+                    max_length=tokenizer.model_max_length,
+                    padding="max_length",
+                    return_tensors='pt',
+                )
                 label_ids = [tokenizer(answer)["input_ids"] for answer in sample["answers"]["text"]]
                 self.items.append(
                     {

--- a/evaluation/datasets/tydiqa.py
+++ b/evaluation/datasets/tydiqa.py
@@ -1,9 +1,8 @@
 # Module for any additional processing required for the TyDi QA dataset
 # HuggingFace dataset link: https://huggingface.co/datasets/tydiqa
 
-import torch
-from torch.utils.data import Dataset
 from jinja2 import Template
+from torch.utils.data import Dataset
 
 TEMPLATE = Template(
     """
@@ -42,16 +41,14 @@ class TyDiQADataset(Dataset):
                     padding=True,
                     return_tensors='pt',
                 )
-                label_ids = [tokenizer(answer)["input_ids"] for answer in sample["answers"]["text"]]
                 self.items.append(
                     {
                         "prompt": prompt,
                         "lang": lang,
                         "input_ids": inputs["input_ids"],
                         "attention_mask": inputs["attention_mask"],
-                        "label_ids": label_ids,
                         "input_len": inputs["attention_mask"].shape[1],
-                        "answers": sample["answers"],
+                        "target_answer": sample["answers"]['text'][0].lower(),
                     }
                 )
     

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -1,9 +1,15 @@
 import logging
 from dataclasses import dataclass, field
+from typing import Optional
 
+from datasets import load_dataset
 from transformers import (
     HfArgumentParser,
+    AutoTokenizer,
+    AutoModelForCausalLM,
 )
+
+from evaluation.datasets.tydiqa import TyDiQADataset
 
 logger = logging.getLogger(__name__)
 
@@ -13,9 +19,17 @@ class EvaluationArguments:
     """
         Arguments for any adjustable params in this evaluation script
     """
-    model_name_or_path: str = field(
+    model_name_or_path: Optional[str] = field(
         default=None,
         metadata={"help": "The model checkpoint that we want to evaluate, could be name or the path."}
+    )
+    config_name: Optional[str] = field(
+        default=None,
+        metadata={"help": "Pretrained config name or path if not the same as model_name."}
+    )
+    tokenizer_name: Optional[str] = field(
+        default=None,
+        metadata={"help": "Pretrained tokenizer name or path if not the same as model_name."}
     )
 
 
@@ -34,13 +48,31 @@ def main():
     logger.info('Beginning evaluation')
 
     # Load model & tokenizer
-    #tokenizer = GPT2Tokenizer.from_pretrained("gpt2", padding_side="left")
-    #tokenizer.pad_token = tokenizer.bos_token
+    logger.info('Loading model...')
+    tokenizer = AutoTokenizer.from_pretrained(eval_args.tokenizer_name or eval_args.model_name_or_path)
+    tokenizer.pad_token = tokenizer.bos_token
+    model = AutoModelForCausalLM.from_pretrained(eval_args.model_name_or_path, pad_token_id=tokenizer.eos_token)
+
+    model.resize_token_embeddings(len(tokenizer))
 
     # Load dataset
-    #target_langs = ["english"]
-    #data = load_dataset("tydiqa", "secondary_task", split="validation")
-    #dataset = TyDiQADataset(data, tm , tokenizer, target_langs)
+    logger.info('Loading TyDiQA...')
+    target_langs = ["english"]
+    data = load_dataset("tydiqa", "secondary_task", split="validation")
+    dataset = TyDiQADataset(data, tokenizer, target_langs)
+
+    for sample in dataset:
+        output = model.generate(
+            input_ids=sample['input_ids'],
+            attention_mask=sample['attention_mask'],
+            max_length=tokenizer.model_max_length + 1,
+            num_beams=4,
+            early_stopping=True,
+        )
+        prompt_len = len(sample['prompt'])
+        decoded_output = tokenizer.decode(output[0], skip_special_tokens=True)
+        answer = decoded_output[prompt_len:]
+        print(answer)
 
 if __name__ == "__main__":
     main()

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -11,6 +11,7 @@ from transformers import (
     HfArgumentParser,
     AutoTokenizer,
     AutoModelForCausalLM,
+    set_seed,
 )
 
 from evaluation.datasets.tydiqa import TyDiQADataset
@@ -55,6 +56,9 @@ def main():
         datefmt="%m/%d/%Y %H:%M:%S",
     )
     logger.setLevel(logging.INFO)
+
+    # set random seed
+    set_seed(42)
 
     logger.info("Beginning evaluation")
 

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -43,6 +43,10 @@ class EvaluationArguments:
         default="outputs",
         metadata={"help": "Directory for saving evaluation outputs."}
     )
+    random_seed: Optional[int] = field(
+        default=24,
+        metadata={"help": "Customized random seed"}
+    )
 
 
 def main():
@@ -58,7 +62,7 @@ def main():
     logger.setLevel(logging.INFO)
 
     # set random seed
-    set_seed(42)
+    set_seed(eval_args.random_seed)
 
     logger.info("Beginning evaluation")
 

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -98,16 +98,17 @@ def main():
         target_answers = sample["target_answer"]
         substring_match = any([target_answer in predicted_answer.lower() for target_answer in target_answers])
         tydiqa_substring_matches += substring_match
-    tydiqa_metrics = dict(substring_matches=tydiqa_substring_matches / len(dataset) * 100)
+    tydiqa_metrics = {
+        "substring_matches": tydiqa_substring_matches / len(dataset) * 100
+    }
     logger.info(f"TyDiQA: {tydiqa_metrics['substring_matches']}% of samples contain substring matches")
 
     # Exporting results
     if eval_args.output_dir:
-        output_dir = f"{eval_args.output_dir}/{datetime.now().strftime('%y%m%d_%H%M%S')}"
-        if not os.path.isdir(output_dir):
-            os.makedirs(output_dir)
+        output_dir = os.path.join(eval_args.output_dir, datetime.now().strftime("%y%m%d_%H%M%S"))
+        os.makedirs(output_dir, exist_ok=True)
         # Exporting TyDiQA results
-        tydiqa_filename = f"{output_dir}/tydiqa.json"
+        tydiqa_filename = os.path.join(output_dir, "tydiqa.json")
         save_json(tydiqa_metrics, tydiqa_filename)
         logger.info(f"TyDiQA: result exported to {tydiqa_filename}")
 

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -33,6 +33,14 @@ def main():
 
     logger.info('Beginning evaluation')
 
+    # Load model & tokenizer
+    #tokenizer = GPT2Tokenizer.from_pretrained("gpt2", padding_side="left")
+    #tokenizer.pad_token = tokenizer.bos_token
+
+    # Load dataset
+    #target_langs = ["english"]
+    #data = load_dataset("tydiqa", "secondary_task", split="validation")
+    #dataset = TyDiQADataset(data, tm , tokenizer, target_langs)
 
 if __name__ == "__main__":
     main()

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -79,7 +79,7 @@ def main():
     data = load_dataset("tydiqa", "secondary_task", split="validation")
     dataset = TyDiQADataset(data, tokenizer, target_langs)
 
-    correct_tydiqa_answer = 0
+    tydiqa_substring_matches = 0
     for sample in tqdm(dataset):
         output = model.generate(
             input_ids=sample["input_ids"].to(torch_device),
@@ -92,10 +92,10 @@ def main():
         predicted_answer = decoded_output[prompt_len:]
         
         target_answers = sample["target_answer"]
-        prediction_contains_target_answer = any([target_answer in predicted_answer.lower() for target_answer in target_answers])
-        correct_tydiqa_answer += prediction_contains_target_answer
-    tydiqa_metrics = dict(correct_answers_percentage=correct_tydiqa_answer / len(dataset) * 100)
-    logger.info(f"TyDiQA: {tydiqa_metrics['correct_answers_percentage']}% of samples answered correctly")
+        substring_match = any([target_answer in predicted_answer.lower() for target_answer in target_answers])
+        tydiqa_substring_matches += substring_match
+    tydiqa_metrics = dict(substring_matches=tydiqa_substring_matches / len(dataset) * 100)
+    logger.info(f"TyDiQA: {tydiqa_metrics['substring_matches']}% of samples contain substring matches")
 
     # Exporting results
     if eval_args.output_dir:

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -90,8 +90,9 @@ def main():
         prompt_len = len(sample["prompt"])
         decoded_output = tokenizer.decode(output[0], skip_special_tokens=True)
         predicted_answer = decoded_output[prompt_len:]
-        target_answer = sample["target_answer"]
-        prediction_contains_target_answer = target_answer in predicted_answer.lower()
+        
+        target_answers = sample["target_answer"]
+        prediction_contains_target_answer = any([target_answer in predicted_answer.lower() for target_answer in target_answers])
         correct_tydiqa_answer += prediction_contains_target_answer
     tydiqa_metrics = dict(correct_answers_percentage=correct_tydiqa_answer / len(dataset) * 100)
     logger.info(f"TyDiQA: {tydiqa_metrics['correct_answers_percentage']}% of samples answered correctly")

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -88,7 +88,7 @@ def main():
         output = model.generate(
             input_ids=sample["input_ids"].to(torch_device),
             attention_mask=sample["attention_mask"].to(torch_device),
-            max_length=sample["input_len"] + 15,
+            max_length=sample["input_len"] * 2,
         )
 
         prompt_len = len(sample["prompt"])

--- a/evaluation/scripts/simple_benchmark.py
+++ b/evaluation/scripts/simple_benchmark.py
@@ -88,7 +88,7 @@ def main():
         output = model.generate(
             input_ids=sample["input_ids"].to(torch_device),
             attention_mask=sample["attention_mask"].to(torch_device),
-            max_length=sample["input_len"] * 2,
+            max_length=min(sample["input_len"]*2, model.config.n_positions),
         )
 
         prompt_len = len(sample["prompt"])

--- a/evaluation/utils/io.py
+++ b/evaluation/utils/io.py
@@ -3,6 +3,5 @@ from typing import Dict
 
 
 def save_json(content: Dict, path: str, indent: int = 4, **kwargs) -> None:
-    print(path)
     with open(path, "w") as f:
         json.dump(content, f, indent=indent, sort_keys=True, **kwargs)

--- a/evaluation/utils/io.py
+++ b/evaluation/utils/io.py
@@ -1,0 +1,8 @@
+import json
+from typing import Dict
+
+
+def save_json(content: Dict, path: str, indent: int = 4, **kwargs) -> None:
+    print(path)
+    with open(path, "w") as f:
+        json.dump(content, f, indent=indent, sort_keys=True, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ datasets==1.11.0
 jinja2==3.0.1
 tensorflow==2.5.0
 torch==1.9.0
+tqdm==4.62.0
 transformers==4.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+datasets==1.11.0
 jinja2==3.0.1
 tensorflow==2.5.0
 torch==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+jinja2==3.0.1
 tensorflow==2.5.0
 torch==1.9.0
 transformers==4.9.1


### PR DESCRIPTION
This PR adds the TyDi QA dataset to the simple benchmark script, including

- Load TyDi QA and reformat the validation dataset for the secondary task into the [prompt](https://github.com/bigscience-workshop/promptsource/blob/main/promptsource/templates/tydiqa/secondary_task/templates.yaml) provided by the prompt WG
- Generate predictions with a decoder model (ie GPT-2)
- Compute and output substring_match metric

Estimated runtime on GPU is ~1 minute; CPU ~15 minutes.
