### PR TITLE
Modify `AutoTask` + adapt `TyDiQA`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ A [simple benchmark](https://github.com/bigscience-workshop/Megatron-DeepSpeed/i
 [WMT](https://huggingface.co/datasets/wmt19) and [TyDi QA](https://huggingface.co/datasets/tydiqa)
 E.g.
 ```shell
-python3 -m evaluation.eval  --model_name_or_path=gpt2  --eval_tasks tydiqa_secondary
+python3 -m evaluation.eval  --model_name_or_path=gpt2  --eval_tasks tydiqa_secondary --output_dir outputs
 ```

--- a/evaluation/eval.py
+++ b/evaluation/eval.py
@@ -39,7 +39,7 @@ class EvaluationArguments:
         default=None,
         metadata={"help": "Identifier for the evaluation run."}
     )
-    is_english_only: Optional[bool] = field(
+    english_only: Optional[bool] = field(
         default=True,
         metadata={"help": "Whether to run evaluation in English only."}
     )
@@ -83,7 +83,7 @@ def main():
             model=model,
             tokenizer=tokenizer,
             device=device, 
-            is_english_only=eval_args.is_english_only,
+            english_only=eval_args.english_only,
         )
         set_seed(train_args.seed)
         task.evaluate()

--- a/evaluation/eval.py
+++ b/evaluation/eval.py
@@ -58,18 +58,18 @@ def main():
     logger = get_logger()
     logger.info(f"Beginning evaluation on device {train_args.device}")
 
-    # # Load model & tokenizer
-    # logger.info("Loading model...")
-    # tokenizer = AutoTokenizer.from_pretrained(eval_args.tokenizer_name or eval_args.model_name_or_path)
-    # tokenizer.pad_token = tokenizer.eos_token
-    # tokenizer.padding_side = "left"
+    # Load model & tokenizer
+    logger.info("Loading model...")
+    tokenizer = AutoTokenizer.from_pretrained(eval_args.tokenizer_name or eval_args.model_name_or_path)
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
 
-    # model = AutoModelForCausalLM.from_pretrained(
-    #     eval_args.model_name_or_path, pad_token_id=tokenizer.eos_token,
-    # )
-    # model.config.pad_token_id = model.config.eos_token_id
-    # model.resize_token_embeddings(len(tokenizer))
-    # model.to(device)
+    model = AutoModelForCausalLM.from_pretrained(
+        eval_args.model_name_or_path, pad_token_id=tokenizer.eos_token,
+    )
+    model.config.pad_token_id = model.config.eos_token_id
+    model.resize_token_embeddings(len(tokenizer))
+    model.to(device)
 
     # Exporting results
     tag = eval_args.tag or datetime.now().strftime("%y%m%d_%H%M%S")
@@ -80,8 +80,8 @@ def main():
         logger.info(f"Benchmarking {eval_task}...")
         task = AutoTask.from_task_name(
             eval_task, 
-            model_name_or_path=eval_args.model_name_or_path, 
-            tokenizer_name=eval_args.tokenizer_name,
+            model=model,
+            tokenizer=tokenizer,
             device=device, 
             is_english_only=eval_args.is_english_only,
         )

--- a/evaluation/models/__init__.py
+++ b/evaluation/models/__init__.py
@@ -1,0 +1,4 @@
+from transformers import AutoModelForCausalLM
+
+def load_model(model_name_or_path):
+    return AutoModelForCausalLM.from_pretrained(model_name_or_path)

--- a/evaluation/models/__init__.py
+++ b/evaluation/models/__init__.py
@@ -1,4 +1,1 @@
-from transformers import AutoModelForCausalLM
-
-def load_model(model_name_or_path):
-    return AutoModelForCausalLM.from_pretrained(model_name_or_path)
+from .loader import load_model

--- a/evaluation/models/__init__.py
+++ b/evaluation/models/__init__.py
@@ -1,1 +1,0 @@
-from .loader import load_model

--- a/evaluation/models/loader.py
+++ b/evaluation/models/loader.py
@@ -1,0 +1,4 @@
+from transformers import AutoModelForCausalLM
+
+def load_model(model_name_or_path):
+    return AutoModelForCausalLM.from_pretrained(model_name_or_path)

--- a/evaluation/tasks/auto_task.py
+++ b/evaluation/tasks/auto_task.py
@@ -1,25 +1,45 @@
 from abc import ABC, abstractmethod
+from typing import Dict
 import os
 
-from evaluation.utils.io import save_json
+from transformers import AutoTokenizer
+
+from evaluation.utils.io import save_json, load_json
+from evaluation.models import load_model
 
 
 class AutoTask(ABC):
-    def __init__(self, tokenizer, model, device):
-        self.tokenizer = tokenizer
-        self.model = model
+    def __init__(
+        self, model_name_or_path, device, is_english_only, tokenizer_name,
+    ):
+        self.model = load_model(model_name_or_path).to(device)
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name or model_name_or_path)
         self.device = device
         self.metrics = {}
+        self.task_config = self.load_task_args(is_english_only)
 
     @classmethod
-    def from_task_name(cls, task_name: str, tokenizer, model, device):
+    def from_task_name(
+        cls, task_name: str, model_name_or_path, device, is_english_only, tokenizer_name="",
+    ):
         all_tasks = cls.__subclasses__()
         for task in all_tasks:
             if task.get_display_name() == task_name:
-                return task(tokenizer=tokenizer, model=model, device=device)
+                return task(
+                    model_name_or_path=model_name_or_path, 
+                    device=device, 
+                    tokenizer_name=tokenizer_name, 
+                    is_english_only=is_english_only,
+                )
         
         raise ValueError(f'Invalid task: {task_name}')
 
+    def load_task_args(self, is_english_only) -> Dict:
+        task_root = os.path.join("evaluation", "tasks", self.get_display_name())        
+        if is_english_only:
+            return load_json(os.path.join(task_root, "english.json"))
+        return load_json(os.path.join(task_root, "multiligual.json"))
+    
     @staticmethod
     @abstractmethod
     def get_display_name() -> str:
@@ -28,6 +48,10 @@ class AutoTask(ABC):
     @abstractmethod
     def evaluate(self) -> None:
         pass
+
+    def train(self) -> None:
+        # TODO: convert to `abstractmethod` once simple_benchmark is ready
+        raise NotImplementedError
 
     def save_metrics(self, output_dir, logger=None) -> str:
         output_filename = os.path.join(output_dir, f"{self.get_display_name()}.json")

--- a/evaluation/tasks/auto_task.py
+++ b/evaluation/tasks/auto_task.py
@@ -2,7 +2,8 @@ from abc import ABC, abstractmethod
 from typing import Dict
 import os
 
-from transformers import AutoTokenizer
+import torch
+from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizerFast
 
 from evaluation.utils.io import save_json, load_json
 from evaluation.models.loader import load_model
@@ -11,9 +12,9 @@ from evaluation.models.loader import load_model
 class AutoTask(ABC):
     def __init__(
         self, 
-        model,
-        tokenizer,
-        device, 
+        model: PreTrainedModel,
+        tokenizer: PreTrainedTokenizerFast,
+        device: torch.device, 
         english_only: bool, 
     ):
         self.model = model
@@ -34,9 +35,9 @@ class AutoTask(ABC):
     def from_task_name(
         cls, 
         task_name: str, 
-        model, 
-        tokenizer,
-        device, 
+        model: PreTrainedModel, 
+        tokenizer: PreTrainedTokenizerFast,
+        device: torch.device, 
         english_only: bool, 
     ):
         task = cls._get_task(task_name)
@@ -53,7 +54,7 @@ class AutoTask(ABC):
         task_name: str, 
         model_name_or_path: str,  
         tokenizer_name: str,
-        device, 
+        device: torch.device, 
         english_only: bool, 
     ):
         task = cls._get_task(task_name)

--- a/evaluation/tasks/auto_task.py
+++ b/evaluation/tasks/auto_task.py
@@ -12,7 +12,7 @@ class AutoTask(ABC):
     def __init__(
         self, 
         device, 
-        is_english_only: bool, 
+        english_only: bool, 
         model=None, 
         tokenizer=None,
         model_name_or_path="",  
@@ -30,14 +30,14 @@ class AutoTask(ABC):
         self.tokenizer = tokenizer
         self.device = device
         self.metrics = {}
-        self.task_config = self.load_task_args(is_english_only)
+        self.task_config = self.load_task_args(english_only)
 
     @classmethod
     def from_task_name(
         cls, 
         task_name: str, 
         device, 
-        is_english_only: bool, 
+        english_only: bool, 
         model=None, 
         tokenizer=None,
         model_name_or_path="",  
@@ -48,7 +48,7 @@ class AutoTask(ABC):
             if task.get_display_name() == task_name:
                 return task(
                     device=device, 
-                    is_english_only=is_english_only,
+                    english_only=english_only,
                     model=model, 
                     tokenizer=tokenizer,
                     model_name_or_path=model_name_or_path,  
@@ -57,9 +57,9 @@ class AutoTask(ABC):
         
         raise ValueError(f'Invalid task: {task_name}')
 
-    def load_task_args(self, is_english_only) -> Dict:
+    def load_task_args(self, english_only) -> Dict:
         task_root = os.path.join("evaluation", "tasks", self.get_display_name())        
-        config_filename =  "english.json" if is_english_only else "multiligual.json"
+        config_filename =  "english.json" if english_only else "multiligual.json"
         return load_json(os.path.join(task_root, config_filename))
     
     @staticmethod

--- a/evaluation/tasks/auto_task.py
+++ b/evaluation/tasks/auto_task.py
@@ -59,9 +59,8 @@ class AutoTask(ABC):
 
     def load_task_args(self, is_english_only) -> Dict:
         task_root = os.path.join("evaluation", "tasks", self.get_display_name())        
-        if is_english_only:
-            return load_json(os.path.join(task_root, "english.json"))
-        return load_json(os.path.join(task_root, "multiligual.json"))
+        config_filename =  "english.json" if is_english_only else "multiligual.json"
+        return load_json(os.path.join(task_root, config_filename))
     
     @staticmethod
     @abstractmethod

--- a/evaluation/tasks/auto_task.py
+++ b/evaluation/tasks/auto_task.py
@@ -5,7 +5,7 @@ import os
 from transformers import AutoTokenizer
 
 from evaluation.utils.io import save_json, load_json
-from evaluation.models import load_model
+from evaluation.models.loader import load_model
 
 
 class AutoTask(ABC):

--- a/evaluation/tasks/tydiqa_secondary/english.json
+++ b/evaluation/tasks/tydiqa_secondary/english.json
@@ -1,0 +1,3 @@
+{
+    "target_langs": ["english"]
+}

--- a/evaluation/tasks/tydiqa_secondary/tydiqa_secondary.py
+++ b/evaluation/tasks/tydiqa_secondary/tydiqa_secondary.py
@@ -28,6 +28,7 @@ TEMPLATE = Template(
 class TyDiQADataset(Dataset):
     def __init__(self, tokenizer, target_langs):
         super().__init__()
+        assert tokenizer.pad_token == tokenizer.eos_token
         tydiqa = load_dataset("tydiqa", "secondary_task", split="validation")
         self.items = []
         
@@ -70,15 +71,8 @@ class TydiqaSecondaryTask(AutoTask):
     @staticmethod
     def get_display_name() -> str:
         return 'tydiqa_secondary'
-    
-    def configure_tokenizer(self):
-        # configure tokenizer
-        self.tokenizer.pad_token = self.tokenizer.eos_token
-        self.tokenizer.padding_side = "left"
 
     def evaluate(self) -> None:
-        self.configure_tokenizer()
-
         dataset = TyDiQADataset(self.tokenizer, target_langs=self.task_config["target_langs"])
 
         substring_matches = 0

--- a/evaluation/tasks/tydiqa_secondary/tydiqa_secondary.py
+++ b/evaluation/tasks/tydiqa_secondary/tydiqa_secondary.py
@@ -70,9 +70,16 @@ class TydiqaSecondaryTask(AutoTask):
     @staticmethod
     def get_display_name() -> str:
         return 'tydiqa_secondary'
+    
+    def configure_tokenizer(self):
+        # configure tokenizer
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.tokenizer.padding_side = "left"
 
     def evaluate(self) -> None:
-        dataset = TyDiQADataset(self.tokenizer, target_langs=["english"])
+        self.configure_tokenizer()
+
+        dataset = TyDiQADataset(self.tokenizer, target_langs=self.task_config["target_langs"])
 
         substring_matches = 0
         for sample in tqdm(dataset, desc=f'Evaluating {self.get_display_name()}'):

--- a/evaluation/train.py
+++ b/evaluation/train.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, List
+import os
+
+import torch
+from transformers import (
+    HfArgumentParser,
+    AutoTokenizer,
+    AutoModelForCausalLM,
+    TrainingArguments,
+    set_seed,
+)
+import evaluation.tasks  # needed for AutoTask.__subclass__() to work correctly
+from evaluation.tasks.auto_task import AutoTask
+from evaluation.utils.log import get_logger
+
+
+@dataclass
+class EvaluationArguments:
+    """
+        Arguments for any adjustable params in this evaluation script
+    """
+    model_name_or_path: str = field(
+        metadata={"help": "The model checkpoint that we want to evaluate, could be name or the path."}
+    )
+    eval_tasks: List[str] = field(
+        metadata={"help": "A list of tasks to run the evaluation on, e.g. tydiqa_secondary"}
+    )
+    config_name: Optional[str] = field(
+        default=None,
+        metadata={"help": "Pretrained config name or path if not the same as model_name."}
+    )
+    tokenizer_name: Optional[str] = field(
+        default=None,
+        metadata={"help": "Pretrained tokenizer name or path if not the same as model_name."}
+    )
+    tag: Optional[str] = field(
+        default=None,
+        metadata={"help": "Identifier for the evaluation run."}
+    )    
+
+
+def main():
+    parser = HfArgumentParser((EvaluationArguments, TrainingArguments))
+    eval_args, train_args = parser.parse_args_into_dataclasses()
+
+    if not eval_args.eval_tasks:
+        raise ValueError('Must provide at least one eval task!')
+    
+    # initialize device
+    device = torch.device(train_args.device)
+
+    logger = get_logger()
+    logger.info(f"Beginning evaluation on device {train_args.device}")
+
+    # Load model & tokenizer
+    logger.info("Loading model...")
+    tokenizer = AutoTokenizer.from_pretrained(eval_args.tokenizer_name or eval_args.model_name_or_path)
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
+
+    model = AutoModelForCausalLM.from_pretrained(
+        eval_args.model_name_or_path, pad_token_id=tokenizer.eos_token,
+    )
+    model.config.pad_token_id = model.config.eos_token_id
+    model.resize_token_embeddings(len(tokenizer))
+    model.to(device)
+
+    # Exporting results
+    tag = eval_args.tag or datetime.now().strftime("%y%m%d_%H%M%S")
+    output_dir = os.path.join(train_args.output_dir, tag)
+    os.makedirs(output_dir, exist_ok=True)
+
+    for eval_task in eval_args.eval_tasks:
+        logger.info(f"Benchmarking {eval_task}...")
+        task = AutoTask.from_task_name(eval_task, tokenizer=tokenizer, model=model, device=device)
+        set_seed(train_args.seed)
+        task.train()
+        task.save_metrics(output_dir, logger)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/utils/io.py
+++ b/evaluation/utils/io.py
@@ -5,3 +5,7 @@ from typing import Dict
 def save_json(content: Dict, path: str, indent: int = 4, **kwargs) -> None:
     with open(path, "w") as f:
         json.dump(content, f, indent=indent, sort_keys=True, **kwargs)
+
+def load_json(path: str) -> Dict:
+    with open(path) as f:
+        return json.load(f)

--- a/evaluation/utils/io.py
+++ b/evaluation/utils/io.py
@@ -7,5 +7,5 @@ def save_json(content: Dict, path: str, indent: int = 4, **kwargs) -> None:
         json.dump(content, f, indent=indent, sort_keys=True, **kwargs)
 
 def load_json(path: str) -> Dict:
-    with open(path) as f:
+    with open(path, "r") as f:
         return json.load(f)


### PR DESCRIPTION
This PR implements the following changes:

* Allow `AutoTask` to be initialized using either a loaded `model` or `model_name_or_path: str` (ditto the tokenizer)
* Support `english_only` flag and the loading of task-specific configuration JSON files
* Separate out modeling loading logic into a separate `load_model()` function to prepare support for models that are not `AutoModelForCausalLM` (e.g. mT5) and Megatron checkpoints