### PR TITLE
Add WMT dataset

### DIFF
--- a/evaluation/tasks/wmt/english.json
+++ b/evaluation/tasks/wmt/english.json
@@ -1,6 +1,5 @@
 {
     "pair": "kk-en",
     "stride": 512,
-    "batch_size": 8,
-    "num_workers": 2
+    "batch_size": 8
 }

--- a/evaluation/tasks/wmt/english.json
+++ b/evaluation/tasks/wmt/english.json
@@ -1,0 +1,6 @@
+{
+    "pair": "kk-en",
+    "stride": 512,
+    "batch_size": 8,
+    "num_workers": 2
+}

--- a/evaluation/tasks/wmt/wmt.py
+++ b/evaluation/tasks/wmt/wmt.py
@@ -1,11 +1,9 @@
 # Module for any additional processing required for the WMT dataset
 # HuggingFace dataset link: https://huggingface.co/datasets/wmt19
 import torch
-from torch.utils.data import Dataset, DataLoader
-from tqdm import tqdm
-
 from datasets import load_dataset
-from torch.utils.data import Dataset
+from torch.utils.data import DataLoader, Dataset
+from tqdm import tqdm
 
 from evaluation.tasks.auto_task import AutoTask
 
@@ -13,9 +11,7 @@ from evaluation.tasks.auto_task import AutoTask
 class WMTEnglishDataset(Dataset):
     def __init__(self, tokenizer, stride=512, max_len=1024, pair="kk-en"):
         super().__init__()
-        assert (
-            "en" in pair
-        ), f"Expected `pair` to contain English, but got {pair} instead"
+        assert "en" in pair, f"Expected `pair` to contain English, but got {pair} instead"
         wmt = load_dataset("wmt19", pair, split="validation")["translation"]
         text_list = [item["en"] for item in wmt]
         text = " ".join(text_list)
@@ -33,19 +29,16 @@ class WMTTask(AutoTask):
     @staticmethod
     def get_display_name() -> str:
         return "wmt"
-    
+
     def evaluate(self) -> None:
-        stride = self.config["stride"]
+        stride = self.task_config["stride"]
         dataset = WMTEnglishDataset(
-            self.tokenizer,
-            stride=stride,
-            max_len=self.model.config.n_positions,
-            pair=self.config["pair"]
+            self.tokenizer, stride=stride, max_len=self.model.config.n_positions, pair=self.task_config["pair"]
         )
         loader = DataLoader(
             dataset,
-            batch_size=self.config["pair"],
-            num_workers=self.config["num_workers"],
+            batch_size=self.task_config["batch_size"],
+            num_workers=self.task_config["num_workers"],
             shuffle=False,
             drop_last=True,
         )

--- a/evaluation/tasks/wmt/wmt.py
+++ b/evaluation/tasks/wmt/wmt.py
@@ -1,2 +1,62 @@
 # Module for any additional processing required for the WMT dataset
 # HuggingFace dataset link: https://huggingface.co/datasets/wmt19
+import torch
+from torch.utils.data import Dataset, DataLoader
+from tqdm import tqdm
+
+from datasets import load_dataset
+from torch.utils.data import Dataset
+
+from evaluation.tasks.auto_task import AutoTask
+
+
+class WMTEnglishDataset(Dataset):
+    def __init__(self, tokenizer, stride=512, max_len=1024, pair="kk-en"):
+        super().__init__()
+        assert (
+            "en" in pair
+        ), f"Expected `pair` to contain English, but got {pair} instead"
+        wmt = load_dataset("wmt19", pair, split="validation")["translation"]
+        text_list = [item["en"] for item in wmt]
+        text = " ".join(text_list)
+        input_ids = tokenizer(text, return_tensors="pt", verbose=False).input_ids.squeeze()
+        self.input_ids = input_ids.unfold(size=max_len, step=stride, dimension=-1)
+
+    def __len__(self):
+        return len(self.input_ids)
+
+    def __getitem__(self, index):
+        return self.input_ids[index]
+
+
+class WMTTask(AutoTask):
+    @staticmethod
+    def get_display_name() -> str:
+        return "wmt"
+    
+    def evaluate(self) -> None:
+        stride = self.config["stride"]
+        dataset = WMTEnglishDataset(
+            self.tokenizer,
+            stride=stride,
+            max_len=self.model.config.n_positions,
+            pair=self.config["pair"]
+        )
+        loader = DataLoader(
+            dataset,
+            batch_size=self.config["pair"],
+            num_workers=self.config["num_workers"],
+            shuffle=False,
+            drop_last=True,
+        )
+        log_likelihoods = []
+        for input_ids in tqdm(loader):
+            input_ids = input_ids.to(self.device)
+            target_ids = input_ids.clone()
+            target_ids[:, :-stride] = -100
+            with torch.no_grad():
+                outputs = self.model(input_ids, labels=target_ids)
+                log_likelihood = outputs[0]
+            log_likelihoods.append(log_likelihood)
+        perplexity = torch.exp(torch.stack(log_likelihoods).sum() / len(loader))
+        self.metrics["perplexity"] = perplexity.item()

--- a/evaluation/tasks/wmt/wmt.py
+++ b/evaluation/tasks/wmt/wmt.py
@@ -1,7 +1,5 @@
 # Module for any additional processing required for the WMT dataset
 # HuggingFace dataset link: https://huggingface.co/datasets/wmt19
-import os
-
 import torch
 from datasets import load_dataset
 from torch.utils.data import DataLoader, Dataset

--- a/evaluation/tasks/wmt/wmt.py
+++ b/evaluation/tasks/wmt/wmt.py
@@ -43,7 +43,7 @@ class WMTTask(AutoTask):
             drop_last=True,
         )
         log_likelihoods = []
-        for input_ids in tqdm(loader):
+        for input_ids in tqdm(loader, desc=f"Evaluating {self.get_display_name()}"):
             input_ids = input_ids.to(self.device)
             target_ids = input_ids.clone()
             target_ids[:, :-stride] = -100


### PR DESCRIPTION
This PR supersedes #42 by creating a `WMTTask` class that inherits from from `AutoTask`. All functionality in the previous PR have been carried over. For convenience, the PR description has been copied and pasted from the original thread.

----
This PR implements the following:
* Load the English validation portion of WMT 19
* Load an AR model to run CLM, with `stride` tokens given as context
* Report perplexity, normalized by the number of tokens

Estimated runtime on GPU is ~1 minute; CPU, ~10 minutes.