### PR TITLE
data path for custom datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ python3 -m evaluation.eval \
     --output_dir outputs
 ```
 
+Note: For toxicity dataset, you have to download the dataset manually from Kaggle [here](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/data) and also pass the `data_dir` argument to the folder.
+
 ## Setup
 
 1. Create virtual environment (one-time).
@@ -64,6 +66,7 @@ task = AutoTask.from_spec(
     "tokenizer_name",
     device,
     english_only,
+    data_dir: Optional
 )
 ```
 

--- a/evaluation/eval.py
+++ b/evaluation/eval.py
@@ -31,7 +31,7 @@ class EvaluationArguments:
     english_only: Optional[bool] = field(default=True, metadata={"help": "Whether to run evaluation in English only."})
 
     data_dir: Optional[str] = field(default=None, metadata={"help": "Path to the local dataset folder"})
-        
+
 
 def main():
     parser = HfArgumentParser((EvaluationArguments, TrainingArguments))
@@ -39,14 +39,18 @@ def main():
 
     if not eval_args.eval_tasks:
         raise ValueError("Must provide at least one eval task!")
-        
-    if 'jigsaw_toxicity_pred' in eval_args.eval_tasks:
+
+    if "jigsaw_toxicity_pred" in eval_args.eval_tasks:
         if eval_args.data_dir is None:
-            raise ValueError("Must provide data path for jigsaw_toxicity_pred. Data needs to be \
-                downloaded manually from Kaggle and saved into a local directory.")
+            raise ValueError(
+                "Must provide data path for jigsaw_toxicity_pred. Data needs to be \
+                downloaded manually from Kaggle and saved into a local directory."
+            )
         if not os.path.exists(eval_args.data_dir):
-            raise ValueError("Data path for jigsaw_toxicity_pred does not exist. Data needs to be \
-                downloaded manually from Kaggle and saved into a local directory.")
+            raise ValueError(
+                "Data path for jigsaw_toxicity_pred does not exist. Data needs to be \
+                downloaded manually from Kaggle and saved into a local directory."
+            )
 
     # initialize device
     device = torch.device(train_args.device)

--- a/evaluation/eval.py
+++ b/evaluation/eval.py
@@ -42,9 +42,11 @@ def main():
         
     if 'jigsaw_toxicity_pred' in eval_args.eval_tasks:
         if eval_args.data_dir is None:
-            raise ValueError("Must provide data path for jigsaw_toxicity_pred")
+            raise ValueError("Must provide data path for jigsaw_toxicity_pred. Data needs to be \
+                downloaded manually from Kaggle and saved into a local directory.")
         if not os.path.exists(eval_args.data_dir):
-            raise ValueError("Data path for jigsaw_toxicity_pred does not exist")
+            raise ValueError("Data path for jigsaw_toxicity_pred does not exist. Data needs to be \
+                downloaded manually from Kaggle and saved into a local directory.")
 
     # initialize device
     device = torch.device(train_args.device)

--- a/evaluation/eval.py
+++ b/evaluation/eval.py
@@ -30,6 +30,8 @@ class EvaluationArguments:
     tag: Optional[str] = field(default=None, metadata={"help": "Identifier for the evaluation run."})
     english_only: Optional[bool] = field(default=True, metadata={"help": "Whether to run evaluation in English only."})
 
+    data_dir: Optional[str] = field(default=None, metadata={"help": "Path to the local dataset folder"})
+        
 
 def main():
     parser = HfArgumentParser((EvaluationArguments, TrainingArguments))
@@ -37,6 +39,12 @@ def main():
 
     if not eval_args.eval_tasks:
         raise ValueError("Must provide at least one eval task!")
+        
+    if 'jigsaw_toxicity_pred' in eval_args.eval_tasks:
+        if eval_args.data_dir is None:
+            raise ValueError("Must provide data path for jigsaw_toxicity_pred")
+        if not os.path.exists(eval_args.data_dir):
+            raise ValueError("Data path for jigsaw_toxicity_pred does not exist")
 
     # initialize device
     device = torch.device(train_args.device)
@@ -71,6 +79,7 @@ def main():
             tokenizer=tokenizer,
             device=device,
             english_only=eval_args.english_only,
+            data_dir=eval_args.data_dir,
         )
         set_seed(train_args.seed)
         task.evaluate()

--- a/evaluation/tasks/auto_task.py
+++ b/evaluation/tasks/auto_task.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizerFast
@@ -16,12 +16,14 @@ class AutoTask(ABC):
         tokenizer: PreTrainedTokenizerFast,
         device: torch.device,
         english_only: bool,
+        data_dir: Optional[str] = None,
     ):
         self.model = model
         self.tokenizer = tokenizer
         self.device = device
         self.metrics = {}
         self.task_config = self.load_task_args(english_only)
+        self.data_dir = data_dir
 
     @classmethod
     def _get_task(cls, task_name):
@@ -39,6 +41,7 @@ class AutoTask(ABC):
         tokenizer: PreTrainedTokenizerFast,
         device: torch.device,
         english_only: bool,
+        data_dir: Optional[str] = None,
     ):
         task = cls._get_task(task_name)
         return task(
@@ -46,6 +49,7 @@ class AutoTask(ABC):
             tokenizer=tokenizer,
             device=device,
             english_only=english_only,
+            data_dir=data_dir,
         )
 
     @classmethod
@@ -56,6 +60,7 @@ class AutoTask(ABC):
         tokenizer_name: str,
         device: torch.device,
         english_only: bool,
+        data_dir: Optional[str] = None,
     ):
         task = cls._get_task(task_name)
         model = load_model(model_name_or_path)
@@ -65,6 +70,7 @@ class AutoTask(ABC):
             tokenizer=tokenizer,
             device=device,
             english_only=english_only,
+            data_dir=data_dir,
         )
 
     def load_task_args(self, english_only) -> Dict:

--- a/evaluation/train.py
+++ b/evaluation/train.py
@@ -30,6 +30,8 @@ class EvaluationArguments:
     tag: Optional[str] = field(default=None, metadata={"help": "Identifier for the evaluation run."})
     english_only: Optional[bool] = field(default=True, metadata={"help": "Whether to run evaluation in English only."})
 
+    data_dir: Optional[str] = field(default=None, metadata={"help": "Path to the local dataset folder"})
+    
 
 def main():
     parser = HfArgumentParser((EvaluationArguments, TrainingArguments))
@@ -37,6 +39,12 @@ def main():
 
     if not eval_args.eval_tasks:
         raise ValueError("Must provide at least one eval task!")
+
+    if 'jigsaw_toxicity_pred' in eval_args.eval_tasks:
+        if eval_args.data_dir is None:
+            raise ValueError("Must provide data path for jigsaw_toxicity_pred")
+        if not os.path.exists(eval_args.data_dir):
+            raise ValueError("Data path for jigsaw_toxicity_pred does not exist")
 
     # initialize device
     device = torch.device(train_args.device)
@@ -71,6 +79,7 @@ def main():
             tokenizer=tokenizer,
             device=device,
             english_only=eval_args.english_only,
+            data_dir=eval_args.data_dir,
         )
         set_seed(train_args.seed)
         task.evaluate()

--- a/evaluation/train.py
+++ b/evaluation/train.py
@@ -31,7 +31,7 @@ class EvaluationArguments:
     english_only: Optional[bool] = field(default=True, metadata={"help": "Whether to run evaluation in English only."})
 
     data_dir: Optional[str] = field(default=None, metadata={"help": "Path to the local dataset folder"})
-    
+
 
 def main():
     parser = HfArgumentParser((EvaluationArguments, TrainingArguments))
@@ -40,7 +40,7 @@ def main():
     if not eval_args.eval_tasks:
         raise ValueError("Must provide at least one eval task!")
 
-    if 'jigsaw_toxicity_pred' in eval_args.eval_tasks:
+    if "jigsaw_toxicity_pred" in eval_args.eval_tasks:
         if eval_args.data_dir is None:
             raise ValueError("Must provide data path for jigsaw_toxicity_pred")
         if not os.path.exists(eval_args.data_dir):


### PR DESCRIPTION
The jigsaw dataset cannot be downloaded with the normal huggingface datasets download API since it needs to be downloaded from Kaggle. This adds support for passing the path to the local data directory for the downloaded dataset from Kaggle. `data_dir` argument is added.

`python -m evaluation.eval --model_name_or_path=gpt2 --eval_tasks jigsaw_toxicity_pred --output_dir /hd2/bs_eval/ --data_dir /hd1/datasets_toxicity`

@trishalaneeraj and I are collaborating on this. She will add a follow-up PR adding the toxicity dataset for evaluation. 