### PR TITLE
fix: update the version of transformers to support use gpt-neo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ jinja2==3.0.1
 tensorflow==2.5.0
 torch==1.9.0
 tqdm==4.62.0
-transformers==4.9.1
+transformers==4.17.0


### PR DESCRIPTION
There is an error would happen if you want to evaluate gpt-neo related models (e.g. "EleutherAI/gpt-neo-125M") using the original version of transformers. This is due to the change of modeling_gpt_neo.py file in the latest version of transformers. 