### PR TITLE
Robustly bump dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-datasets==1.11.0
-jinja2==3.0.1
-tensorflow==2.5.0
-torch==1.9.0
-tqdm==4.62.0
-transformers==4.9.1
-sacrebleu==2.0.0
+torch>=1.9.0
+transformers>=4.9.1
+datasets>=1.11.0
+jinja2>=3.0.1
+tqdm>=4.62.0
+sacrebleu>=2.0.0


### PR DESCRIPTION
In light of #74, this PR flexibly bumps project dependency versions by replacing hardcoded `==` version requirements with `>=`. This will allow `pip` to install the latest versions when possible and also resolve the test CI error.

Additionally, 
* The unnecessary `tensorflow` dependency is removed
* Dependencies are re-ordered to give priority to `torch` and `transformers`